### PR TITLE
Fixed deployment task

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build library
         run: npm run build
 
+      - name: Build VitePress documentation
+        run: npm run docs:build
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
This pull request adds a step to the deployment workflow to ensure that the VitePress documentation is built before deploying the site.

Deployment workflow update:

* Added a new job step in `.github/workflows/deploy-pages.yml` to run `npm run docs:build`, which builds the VitePress documentation prior to deployment.