### PR TITLE
refactor: explicit handshake state machine and EventEmitter lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   resolves to `./dist/index.js` (ESM) and `require` to `./dist/index.cjs`
   (CommonJS). Previously `import` pointed at a missing `index.mjs` and `require`
   at the ESM build
+- Disconnecting or cleaning up a channel mid-handshake now rejects the pending
+  connect() promise instead of leaving it hanging forever
 
 ### Added
 
@@ -33,6 +35,13 @@ and this project adheres to
 - Playwright E2E suite (`npm run test:e2e`) exercising real cross-origin iframe
   and window.open communication in Chromium: handshake round-trip, handshake
   timeout, origin rejection, reconnect, and popup-close detection
+- `HandshakeController`: explicit handshake state machine
+  (`idle | awaiting-ack | completed | timed-out | failed`) used by both
+  channels; late or duplicate handshake events are now explicit no-ops, and
+  channels expose a readonly `handshakeState` getter
+- `EventEmitter.destroy()` removes all listeners and rejects future
+  subscriptions with a warning (no-op unsubscribe) instead of silent
+  registration; new `onLimitExceeded: 'throw' | 'warn'` constructor option
 - Root `SECURITY.md` and `CODE_OF_CONDUCT.md`
 
 ### Changed

--- a/src/communication/BaseChannel.ts
+++ b/src/communication/BaseChannel.ts
@@ -185,7 +185,7 @@ export abstract class BaseChannel {
      */
     public destroy(): void {
         this._teardownMessageListener();
-        this._emitter.removeAllListeners();
+        this._emitter.destroy();
         this._messageHandler = null;
         this._state = 'disconnected';
         this._logger.debug('Channel destroyed');

--- a/src/communication/HandshakeController.ts
+++ b/src/communication/HandshakeController.ts
@@ -16,11 +16,12 @@ import type { Logger } from '../utils/Logger';
 /**
  * Handshake lifecycle states
  *
- * - 'idle': no handshake in progress
+ * - 'idle': no handshake in progress (also the state after reset(),
+ *   which rejects any in-flight handshake as cancelled)
  * - 'awaiting-ack': handshake started, waiting for acknowledgment
  * - 'completed': acknowledgment received, handshake succeeded
  * - 'timed-out': no acknowledgment within the timeout window
- * - 'failed': handshake failed or was cancelled
+ * - 'failed': fail() was called while awaiting acknowledgment
  */
 export type HandshakeState = 'idle' | 'awaiting-ack' | 'completed' | 'timed-out' | 'failed';
 

--- a/src/communication/HandshakeController.ts
+++ b/src/communication/HandshakeController.ts
@@ -1,0 +1,171 @@
+/**
+ * @file HandshakeController.ts
+ * @description Explicit state machine for the connection handshake
+ * @module parley-js/communication
+ *
+ * Owns the handshake promise, its timeout, and the state transitions, so
+ * channels no longer juggle nullable resolve/reject/timeout triples. Late
+ * or duplicate events (e.g. an ACK arriving after the timeout already
+ * fired) are ignored explicitly instead of relying on null checks.
+ */
+
+import { ConnectionError } from '../errors/ErrorTypes';
+import { CONNECTION_ERRORS } from '../errors/ErrorCodes';
+import type { Logger } from '../utils/Logger';
+
+/**
+ * Handshake lifecycle states
+ *
+ * - 'idle': no handshake in progress
+ * - 'awaiting-ack': handshake started, waiting for acknowledgment
+ * - 'completed': acknowledgment received, handshake succeeded
+ * - 'timed-out': no acknowledgment within the timeout window
+ * - 'failed': handshake failed or was cancelled
+ */
+export type HandshakeState = 'idle' | 'awaiting-ack' | 'completed' | 'timed-out' | 'failed';
+
+/**
+ * Controls a single connection handshake
+ *
+ * @example
+ * ```typescript
+ * const handshake = new HandshakeController(logger);
+ *
+ * // Initiator side
+ * const done = handshake.start(5000);
+ * sendHandshakeInit();
+ * await done; // resolves on acknowledge(), rejects on timeout/fail()
+ *
+ * // When the ACK message arrives
+ * handshake.acknowledge();
+ * ```
+ */
+export class HandshakeController {
+    private _state: HandshakeState = 'idle';
+    private _resolve: (() => void) | null = null;
+    private _reject: ((error: Error) => void) | null = null;
+    private _timeout: ReturnType<typeof setTimeout> | null = null;
+    private readonly _logger?: Logger;
+
+    constructor(logger?: Logger) {
+        this._logger = logger;
+    }
+
+    /**
+     * Current handshake state
+     */
+    public get state(): HandshakeState {
+        return this._state;
+    }
+
+    /**
+     * Begin waiting for a handshake acknowledgment
+     *
+     * @param timeoutMs - Milliseconds to wait before rejecting
+     * @returns Promise that resolves on acknowledge() and rejects on
+     *          timeout, fail(), or reset()
+     */
+    public start(timeoutMs: number): Promise<void> {
+        if (this._state === 'awaiting-ack') {
+            // A handshake is already in flight; cancel it before starting over
+            this._logger?.warn('Handshake restarted while one was in progress');
+            this.reset();
+        }
+
+        this._state = 'awaiting-ack';
+
+        return new Promise<void>((resolve, reject) => {
+            this._resolve = resolve;
+            this._reject = reject;
+
+            this._timeout = setTimeout(() => {
+                if (this._state !== 'awaiting-ack') {
+                    return;
+                }
+                this._state = 'timed-out';
+                const rejectHandshake = this._reject;
+                this._clear();
+                rejectHandshake?.(
+                    new ConnectionError(
+                        'Handshake timeout',
+                        undefined,
+                        CONNECTION_ERRORS.HANDSHAKE_FAILED
+                    )
+                );
+            }, timeoutMs);
+        });
+    }
+
+    /**
+     * Complete the handshake successfully
+     *
+     * Ignored (with a debug log) unless a handshake is awaiting
+     * acknowledgment - this makes late or duplicate ACKs explicit no-ops.
+     */
+    public acknowledge(): void {
+        if (this._state !== 'awaiting-ack') {
+            this._logger?.debug(`Handshake ack ignored (state: ${this._state})`);
+            return;
+        }
+
+        this._state = 'completed';
+        const resolveHandshake = this._resolve;
+        this._clear();
+        resolveHandshake?.();
+    }
+
+    /**
+     * Fail the handshake with a specific error
+     *
+     * Ignored unless a handshake is awaiting acknowledgment.
+     *
+     * @param error - Error to reject the handshake promise with
+     */
+    public fail(error: Error): void {
+        if (this._state !== 'awaiting-ack') {
+            this._logger?.debug(`Handshake failure ignored (state: ${this._state})`);
+            return;
+        }
+
+        this._state = 'failed';
+        const rejectHandshake = this._reject;
+        this._clear();
+        rejectHandshake?.(error);
+    }
+
+    /**
+     * Reset to idle, cancelling any in-flight handshake
+     *
+     * If a handshake is awaiting acknowledgment its promise is rejected so
+     * callers of start() are never left hanging.
+     */
+    public reset(): void {
+        if (this._state === 'awaiting-ack' && this._reject) {
+            const rejectHandshake = this._reject;
+            this._clear();
+            rejectHandshake(
+                new ConnectionError(
+                    'Handshake cancelled',
+                    undefined,
+                    CONNECTION_ERRORS.HANDSHAKE_FAILED
+                )
+            );
+        } else {
+            this._clear();
+        }
+
+        this._state = 'idle';
+    }
+
+    /**
+     * Clear the timeout and promise callbacks
+     */
+    private _clear(): void {
+        if (this._timeout) {
+            clearTimeout(this._timeout);
+            this._timeout = null;
+        }
+        this._resolve = null;
+        this._reject = null;
+    }
+}

--- a/src/communication/IframeChannel.ts
+++ b/src/communication/IframeChannel.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseChannel } from './BaseChannel';
+import { HandshakeController, type HandshakeState } from './HandshakeController';
 import { Logger } from '../utils/Logger';
 import { ConnectionError } from '../errors/ErrorTypes';
 import { CONNECTION_ERRORS } from '../errors/ErrorCodes';
@@ -58,11 +59,9 @@ export class IframeChannel extends BaseChannel {
     private _targetOrigin: string = '';
 
     /**
-     * Pending handshake promise resolvers
+     * Handshake state machine
      */
-    private _handshakeResolve: (() => void) | null = null;
-    private _handshakeReject: ((error: Error) => void) | null = null;
-    private _handshakeTimeout: ReturnType<typeof setTimeout> | null = null;
+    private readonly _handshake: HandshakeController;
 
     /**
      * Memoized connection promise to prevent race conditions
@@ -80,6 +79,14 @@ export class IframeChannel extends BaseChannel {
         super(options, logger);
         this._logger =
             logger?.child('IframeChannel') ?? new Logger(undefined, '[Parley][IframeChannel]');
+        this._handshake = new HandshakeController(this._logger);
+    }
+
+    /**
+     * Current handshake state
+     */
+    public get handshakeState(): HandshakeState {
+        return this._handshake.state;
     }
 
     /**
@@ -398,21 +405,7 @@ export class IframeChannel extends BaseChannel {
      * Wait for handshake to complete
      */
     private _waitForHandshake(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this._handshakeResolve = resolve;
-            this._handshakeReject = reject;
-
-            this._handshakeTimeout = setTimeout(() => {
-                this._handshakeReject?.(
-                    new ConnectionError(
-                        'Handshake timeout',
-                        undefined,
-                        CONNECTION_ERRORS.HANDSHAKE_FAILED
-                    )
-                );
-                this._clearHandshake();
-            }, this._options.handshakeTimeout);
-        });
+        return this._handshake.start(this._options.handshakeTimeout);
     }
 
     /**
@@ -437,8 +430,7 @@ export class IframeChannel extends BaseChannel {
         this.send(ackMessage, source, event.origin);
 
         // Complete handshake
-        this._handshakeResolve?.();
-        this._clearHandshake();
+        this._handshake.acknowledge();
     }
 
     /**
@@ -446,27 +438,14 @@ export class IframeChannel extends BaseChannel {
      */
     private _handleHandshakeAck(): void {
         this._logger.debug('Received handshake ack');
-        this._handshakeResolve?.();
-        this._clearHandshake();
-    }
-
-    /**
-     * Clear handshake state
-     */
-    private _clearHandshake(): void {
-        if (this._handshakeTimeout) {
-            clearTimeout(this._handshakeTimeout);
-            this._handshakeTimeout = null;
-        }
-        this._handshakeResolve = null;
-        this._handshakeReject = null;
+        this._handshake.acknowledge();
     }
 
     /**
      * Clean up channel resources
      */
     private _cleanup(): void {
-        this._clearHandshake();
+        this._handshake.reset();
         this._teardownMessageListener();
         this._iframe = null;
         this._parentWindow = null;

--- a/src/communication/WindowChannel.ts
+++ b/src/communication/WindowChannel.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseChannel } from './BaseChannel';
+import { HandshakeController, type HandshakeState } from './HandshakeController';
 import { Logger } from '../utils/Logger';
 import { ConnectionError } from '../errors/ErrorTypes';
 import { CONNECTION_ERRORS } from '../errors/ErrorCodes';
@@ -54,11 +55,9 @@ export class WindowChannel extends BaseChannel {
     private _pollInterval: ReturnType<typeof setInterval> | null = null;
 
     /**
-     * Pending handshake promise resolvers
+     * Handshake state machine
      */
-    private _handshakeResolve: (() => void) | null = null;
-    private _handshakeReject: ((error: Error) => void) | null = null;
-    private _handshakeTimeout: ReturnType<typeof setTimeout> | null = null;
+    private readonly _handshake: HandshakeController;
 
     /**
      * Memoized connection promise to prevent race conditions
@@ -76,6 +75,14 @@ export class WindowChannel extends BaseChannel {
         super(options, logger);
         this._logger =
             logger?.child('WindowChannel') ?? new Logger(undefined, '[Parley][WindowChannel]');
+        this._handshake = new HandshakeController(this._logger);
+    }
+
+    /**
+     * Current handshake state
+     */
+    public get handshakeState(): HandshakeState {
+        return this._handshake.state;
     }
 
     /**
@@ -394,21 +401,7 @@ export class WindowChannel extends BaseChannel {
      * Wait for handshake to complete
      */
     private _waitForHandshake(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this._handshakeResolve = resolve;
-            this._handshakeReject = reject;
-
-            this._handshakeTimeout = setTimeout(() => {
-                this._handshakeReject?.(
-                    new ConnectionError(
-                        'Handshake timeout',
-                        undefined,
-                        CONNECTION_ERRORS.HANDSHAKE_FAILED
-                    )
-                );
-                this._clearHandshake();
-            }, this._options.handshakeTimeout);
-        });
+        return this._handshake.start(this._options.handshakeTimeout);
     }
 
     /**
@@ -433,8 +426,7 @@ export class WindowChannel extends BaseChannel {
         this.send(ackMessage, source, event.origin);
 
         // Complete handshake
-        this._handshakeResolve?.();
-        this._clearHandshake();
+        this._handshake.acknowledge();
     }
 
     /**
@@ -442,20 +434,7 @@ export class WindowChannel extends BaseChannel {
      */
     private _handleHandshakeAck(): void {
         this._logger.debug('Received handshake ack');
-        this._handshakeResolve?.();
-        this._clearHandshake();
-    }
-
-    /**
-     * Clear handshake state
-     */
-    private _clearHandshake(): void {
-        if (this._handshakeTimeout) {
-            clearTimeout(this._handshakeTimeout);
-            this._handshakeTimeout = null;
-        }
-        this._handshakeResolve = null;
-        this._handshakeReject = null;
+        this._handshake.acknowledge();
     }
 
     /**
@@ -488,7 +467,7 @@ export class WindowChannel extends BaseChannel {
      * Clean up channel resources
      */
     private _cleanup(): void {
-        this._clearHandshake();
+        this._handshake.reset();
         this._stopWindowPolling();
         this._teardownMessageListener();
         this._targetWindow = null;

--- a/src/core/Parley.ts
+++ b/src/core/Parley.ts
@@ -799,7 +799,7 @@ export class Parley {
         this._pendingRequests.clear();
 
         // Clean up
-        this._emitter.removeAllListeners();
+        this._emitter.destroy();
         this._registry.clear();
         this._targets.destroy();
         this._analyticsHandlers.clear();

--- a/src/events/EventEmitter.ts
+++ b/src/events/EventEmitter.ts
@@ -312,9 +312,9 @@ export class EventEmitter {
     /**
      * Destroy the emitter
      *
-     * Removes all listeners and rejects future subscriptions. Subscribing
-     * after destroy logs a warning and returns a no-op unsubscribe instead
-     * of throwing, because teardown ordering races are common.
+     * Removes all listeners and ignores future subscriptions: on()/once()
+     * after destroy log a warning and return a no-op unsubscribe rather
+     * than throwing, because teardown ordering races are common.
      */
     public destroy(): void {
         this._destroyed = true;

--- a/src/events/EventEmitter.ts
+++ b/src/events/EventEmitter.ts
@@ -21,6 +21,14 @@ interface ListenerEntry<T = unknown> {
 }
 
 /**
+ * Behavior when the max listener limit is exceeded
+ *
+ * - 'throw': throw an Error (default; surfaces leaks early)
+ * - 'warn': log a console warning and register the listener anyway
+ */
+export type MaxListenersExceededBehavior = 'throw' | 'warn';
+
+/**
  * Internal event emitter class for Parley
  *
  * Provides a type-safe pub/sub implementation with support for:
@@ -57,12 +65,28 @@ export class EventEmitter {
     private _maxListeners: number = 100;
 
     /**
+     * What to do when the max listener limit is exceeded
+     */
+    private readonly _onLimitExceeded: MaxListenersExceededBehavior;
+
+    /**
+     * Whether destroy() has been called
+     */
+    private _destroyed: boolean = false;
+
+    /**
      * Creates a new EventEmitter instance
      *
      * @param maxListeners - Maximum listeners per event (default: 100)
+     * @param onLimitExceeded - Behavior when the limit is exceeded
+     *                          (default: 'throw')
      */
-    constructor(maxListeners: number = 100) {
+    constructor(
+        maxListeners: number = 100,
+        onLimitExceeded: MaxListenersExceededBehavior = 'throw'
+    ) {
         this._maxListeners = maxListeners;
+        this._onLimitExceeded = onLimitExceeded;
     }
 
     /**
@@ -272,6 +296,25 @@ export class EventEmitter {
     }
 
     /**
+     * Destroy the emitter
+     *
+     * Removes all listeners and rejects future subscriptions. Subscribing
+     * after destroy logs a warning and returns a no-op unsubscribe instead
+     * of throwing, because teardown ordering races are common.
+     */
+    public destroy(): void {
+        this._destroyed = true;
+        this._listeners.clear();
+    }
+
+    /**
+     * Whether destroy() has been called
+     */
+    public get isDestroyed(): boolean {
+        return this._destroyed;
+    }
+
+    /**
      * Internal method to add a listener
      *
      * @param event - Event name
@@ -284,6 +327,13 @@ export class EventEmitter {
         handler: EventHandler<T>,
         once: boolean
     ): () => void {
+        if (this._destroyed) {
+            console.warn(`Listener for "${event}" ignored: this EventEmitter has been destroyed.`);
+            return () => {
+                // No-op: nothing was registered
+            };
+        }
+
         let listeners = this._listeners.get(event);
 
         if (!listeners) {
@@ -294,11 +344,15 @@ export class EventEmitter {
         // Prevent memory leaks by enforcing max listener limit
         // Follows Node.js EventEmitter pattern of throwing on limit exceeded
         if (this._maxListeners > 0 && listeners.length >= this._maxListeners) {
-            throw new Error(
+            const message =
                 `Max listeners (${this._maxListeners}) exceeded for event "${event}". ` +
-                    'This likely indicates a memory leak. ' +
-                    `Use emitter.setMaxListeners(n) to increase the limit if this is intentional.`
-            );
+                'This likely indicates a memory leak. ' +
+                `Use emitter.setMaxListeners(n) to increase the limit if this is intentional.`;
+
+            if (this._onLimitExceeded === 'throw') {
+                throw new Error(message);
+            }
+            console.warn(message);
         }
 
         const entry: ListenerEntry = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export type { HeartbeatSendFunction, HeartbeatFailureHandler } from './core/Hear
 export { BaseChannel } from './communication/BaseChannel';
 export { IframeChannel } from './communication/IframeChannel';
 export { WindowChannel } from './communication/WindowChannel';
+export { HandshakeController, type HandshakeState } from './communication/HandshakeController';
 
 // Validation
 export { SchemaValidator, validateSchema } from './validation/SchemaValidator';
@@ -98,11 +99,16 @@ export {
     SERIALIZATION_ERRORS,
     CONNECTION_ERRORS,
     CONFIG_ERRORS,
+    GENERAL_ERRORS,
     type ErrorCode,
 } from './errors/ErrorCodes';
 
 // Events
-export { EventEmitter, type EventHandler } from './events/EventEmitter';
+export {
+    EventEmitter,
+    type EventHandler,
+    type MaxListenersExceededBehavior,
+} from './events/EventEmitter';
 export {
     SYSTEM_EVENTS,
     type SystemEventName,

--- a/tests/unit/EventEmitter.test.ts
+++ b/tests/unit/EventEmitter.test.ts
@@ -632,4 +632,80 @@ describe('EventEmitter', () => {
             expect(handler2).toHaveBeenCalledWith('second');
         });
     });
+
+    describe('destroy()', () => {
+        it('should remove all listeners', () => {
+            const local = new EventEmitter();
+            local.on('a', vi.fn());
+            local.on('b', vi.fn());
+
+            local.destroy();
+
+            expect(local.eventNames()).toEqual([]);
+            expect(local.isDestroyed).toBe(true);
+        });
+
+        it('should not invoke handlers emitted after destroy', async () => {
+            const local = new EventEmitter();
+            const handler = vi.fn();
+            local.on('test', handler);
+
+            local.destroy();
+            await local.emit('test', 'data');
+            local.emitSync('test', 'data');
+
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('should warn and return a no-op unsubscribe for on() after destroy', () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const local = new EventEmitter();
+            local.destroy();
+
+            const handler = vi.fn();
+            const unsubscribe = local.on('test', handler);
+
+            expect(warnSpy).toHaveBeenCalled();
+            expect(local.listenerCount('test')).toBe(0);
+            expect(() => unsubscribe()).not.toThrow();
+
+            warnSpy.mockRestore();
+        });
+
+        it('should warn and return a no-op unsubscribe for once() after destroy', () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const local = new EventEmitter();
+            local.destroy();
+
+            local.once('test', vi.fn());
+
+            expect(warnSpy).toHaveBeenCalled();
+            expect(local.listenerCount('test')).toBe(0);
+
+            warnSpy.mockRestore();
+        });
+    });
+
+    describe('onLimitExceeded behavior', () => {
+        it('should throw by default when the limit is exceeded', () => {
+            const local = new EventEmitter(2);
+            local.on('test', vi.fn());
+            local.on('test', vi.fn());
+
+            expect(() => local.on('test', vi.fn())).toThrow(/Max listeners/);
+        });
+
+        it('should warn and still register in warn mode', () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const local = new EventEmitter(2, 'warn');
+            local.on('test', vi.fn());
+            local.on('test', vi.fn());
+
+            expect(() => local.on('test', vi.fn())).not.toThrow();
+            expect(warnSpy).toHaveBeenCalled();
+            expect(local.listenerCount('test')).toBe(3);
+
+            warnSpy.mockRestore();
+        });
+    });
 });

--- a/tests/unit/HandshakeController.test.ts
+++ b/tests/unit/HandshakeController.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @file HandshakeController.test.ts
+ * @description Unit tests for the HandshakeController state machine
+ * @module tests/unit
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HandshakeController } from '../../src/communication/HandshakeController';
+import { ConnectionError } from '../../src/errors/ErrorTypes';
+import { CONNECTION_ERRORS } from '../../src/errors/ErrorCodes';
+
+describe('HandshakeController', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts in the idle state', () => {
+        const controller = new HandshakeController();
+        expect(controller.state).toBe('idle');
+    });
+
+    it('resolves and reaches completed when acknowledged before timeout', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+        expect(controller.state).toBe('awaiting-ack');
+
+        controller.acknowledge();
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(controller.state).toBe('completed');
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('rejects with HANDSHAKE_FAILED on timeout', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+        const assertion = expect(promise).rejects.toMatchObject({
+            code: CONNECTION_ERRORS.HANDSHAKE_FAILED,
+            message: 'Handshake timeout',
+        });
+
+        vi.advanceTimersByTime(5000);
+
+        await assertion;
+        expect(controller.state).toBe('timed-out');
+    });
+
+    it('ignores a late acknowledgment after timeout', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+        promise.catch(() => {
+            // Rejection handled; this test is about the late ACK
+        });
+
+        vi.advanceTimersByTime(5000);
+        await vi.runAllTimersAsync();
+
+        // Late ACK must not throw or change state
+        expect(() => controller.acknowledge()).not.toThrow();
+        expect(controller.state).toBe('timed-out');
+    });
+
+    it('ignores a duplicate acknowledgment', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+
+        controller.acknowledge();
+        controller.acknowledge();
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(controller.state).toBe('completed');
+    });
+
+    it('rejects with the given error on fail()', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+
+        controller.fail(
+            new ConnectionError('Target closed', undefined, CONNECTION_ERRORS.CLOSED)
+        );
+
+        await expect(promise).rejects.toMatchObject({ code: CONNECTION_ERRORS.CLOSED });
+        expect(controller.state).toBe('failed');
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('ignores fail() after completion', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+
+        controller.acknowledge();
+        controller.fail(new Error('too late'));
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(controller.state).toBe('completed');
+    });
+
+    it('rejects an in-flight handshake on reset() and returns to idle', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+
+        const assertion = expect(promise).rejects.toMatchObject({
+            code: CONNECTION_ERRORS.HANDSHAKE_FAILED,
+            message: 'Handshake cancelled',
+        });
+        controller.reset();
+
+        await assertion;
+        expect(controller.state).toBe('idle');
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('allows a fresh handshake after reset()', async () => {
+        const controller = new HandshakeController();
+        const first = controller.start(5000);
+        first.catch(() => {
+            // Cancelled by reset below
+        });
+        controller.reset();
+
+        const second = controller.start(5000);
+        controller.acknowledge();
+
+        await expect(second).resolves.toBeUndefined();
+        expect(controller.state).toBe('completed');
+    });
+
+    it('cancels the previous handshake when start() is called twice', async () => {
+        const controller = new HandshakeController();
+        const first = controller.start(5000);
+        const firstAssertion = expect(first).rejects.toMatchObject({
+            message: 'Handshake cancelled',
+        });
+
+        const second = controller.start(5000);
+        controller.acknowledge();
+
+        await firstAssertion;
+        await expect(second).resolves.toBeUndefined();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('does not fire the timeout after acknowledgment', async () => {
+        const controller = new HandshakeController();
+        const promise = controller.start(5000);
+
+        controller.acknowledge();
+        vi.advanceTimersByTime(10000);
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(controller.state).toBe('completed');
+    });
+});


### PR DESCRIPTION
Stacked on #19 (the E2E suite is the safety net for this connection-path change).

## HandshakeController

New `src/communication/HandshakeController.ts`: an explicit state machine (`idle | awaiting-ack | completed | timed-out | failed`) owning the handshake promise and timeout. `IframeChannel` and `WindowChannel` replace their nullable `_handshakeResolve`/`_handshakeReject`/`_handshakeTimeout` triples with it.

- Late or duplicate ACKs (e.g. an ACK arriving after the timeout fired) are now explicit, logged no-ops instead of implicit null-check behavior.
- **Behavior fix**: cleanup/disconnect mid-handshake previously cleared the resolvers and left the pending `connect()` promise hanging forever; `reset()` now rejects it with `Handshake cancelled`.
- Channels expose a readonly `handshakeState` getter.

## EventEmitter lifecycle

- `destroy()`: clears all listeners, marks the emitter dead; `on()/once()` after destroy warn and return a no-op unsubscribe (no throw - teardown ordering races are common).
- New constructor option `onLimitExceeded: 'throw' | 'warn'` (default `'throw'` keeps the existing leak detection).
- `BaseChannel.destroy()` and `Parley.destroy()` now call `emitter.destroy()`.

## Testing

New `tests/unit/HandshakeController.test.ts` (10 tests, fake timers): ACK before timeout, timeout rejection, late ACK ignored, double ACK, fail-after-complete ignored, reset cancels in-flight handshake, restart cancels previous, no timer leaks. EventEmitter destroy/limit tests added. Full gate green: 861 unit/integration tests, 5 E2E, typecheck, eslint, build, size.

Note for reviewers: this touches the security-sensitive connection path - the handshake timeout error message and `ERR_CONNECTION_HANDSHAKE_FAILED` code are preserved exactly (asserted by the E2E suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)