### PR TITLE
fix(core): disconnect the peer that sent the notification, not the first target

### DIFF
--- a/.changeset/tidy-moons-repair.md
+++ b/.changeset/tidy-moons-repair.md
@@ -1,0 +1,8 @@
+---
+'ignite-parleyjs': patch
+---
+
+Fixed disconnect notifications tearing down the wrong connection: the handler
+now disconnects the target that actually sent the notification (identified via
+message metadata) instead of the first connected target. With multiple connected
+targets, one peer disconnecting no longer kills an unrelated connection.

--- a/src/core/ConnectionManager.ts
+++ b/src/core/ConnectionManager.ts
@@ -447,8 +447,12 @@ export class ConnectionManager {
         // Handle disconnect notifications from other side
         this._registry.addHandler(
             SYSTEM_MESSAGE_TYPES.DISCONNECT,
-            (payload: DisconnectPayload, respond: (response: unknown) => void) => {
-                this._handleDisconnectNotification(payload);
+            (
+                payload: DisconnectPayload,
+                respond: (response: unknown) => void,
+                metadata: MessageMetadata
+            ) => {
+                this._handleDisconnectNotification(payload, metadata.senderId);
                 respond({ acknowledged: true, timestamp: getTimestamp() });
             },
             true // internal
@@ -493,20 +497,31 @@ export class ConnectionManager {
 
     /**
      * Handle disconnect notification from other side
+     *
+     * @param payload - Disconnect payload from the remote peer
+     * @param senderTargetId - Local target ID of the peer that sent the
+     *        notification (from message metadata, not the spoofable payload)
      */
-    private _handleDisconnectNotification(payload: DisconnectPayload): void {
+    private _handleDisconnectNotification(
+        payload: DisconnectPayload,
+        senderTargetId: string
+    ): void {
         this._logger.info('Received disconnect notification', {
             senderId: payload.senderId,
+            targetId: senderTargetId,
             reason: payload.reason,
         });
 
-        // Find the target that sent this disconnect
-        // For now, we look for any connected target (in most cases there's only one)
-        for (const target of this._targets.getConnected()) {
-            // Perform local disconnect without sending notification back
-            this.performLocalDisconnect(target.id, payload.reason);
-            break; // Only disconnect one target per notification
+        const target = this._targets.get(senderTargetId);
+        if (!target) {
+            this._logger.warn('Disconnect notification from unknown target', {
+                targetId: senderTargetId,
+            });
+            return;
         }
+
+        // Perform local disconnect without sending notification back
+        this.performLocalDisconnect(senderTargetId, payload.reason);
     }
 
     /**

--- a/tests/unit/ConnectionManager.test.ts
+++ b/tests/unit/ConnectionManager.test.ts
@@ -9,7 +9,7 @@
  * - Ignoring notifications from unknown targets
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ConnectionManager } from '../../src/core/ConnectionManager';
 import { MessageRegistry } from '../../src/core/MessageRegistry';
 import { TargetManager } from '../../src/core/TargetManager';
@@ -24,6 +24,7 @@ describe('ConnectionManager', () => {
     let registry: MessageRegistry;
     let targets: TargetManager;
     let emitter: EventEmitter;
+    let manager: ConnectionManager;
     let rejectPendingForTarget: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
@@ -33,7 +34,7 @@ describe('ConnectionManager', () => {
         emitter = new EventEmitter();
         rejectPendingForTarget = vi.fn();
 
-        new ConnectionManager({
+        manager = new ConnectionManager({
             config: { instanceId: 'local-instance' } as ResolvedConfig,
             logger: logger as any,
             emitter,
@@ -44,6 +45,13 @@ describe('ConnectionManager', () => {
             sendSystemMessage: () => Promise.resolve(undefined),
             rejectPendingForTarget,
         });
+    });
+
+    afterEach(() => {
+        manager.destroy();
+        targets.destroy();
+        registry.clear();
+        emitter.destroy();
     });
 
     describe('disconnect notification handling', () => {

--- a/tests/unit/ConnectionManager.test.ts
+++ b/tests/unit/ConnectionManager.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @file ConnectionManager.test.ts
+ * @description Unit tests for ConnectionManager class
+ * @module tests/unit
+ *
+ * Tests disconnect notification handling:
+ * - Disconnecting exactly the target that sent the notification
+ * - Leaving unrelated connected targets intact
+ * - Ignoring notifications from unknown targets
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ConnectionManager } from '../../src/core/ConnectionManager';
+import { MessageRegistry } from '../../src/core/MessageRegistry';
+import { TargetManager } from '../../src/core/TargetManager';
+import { EventEmitter } from '../../src/events/EventEmitter';
+import { SYSTEM_EVENTS } from '../../src/events/SystemEvents';
+import { SYSTEM_MESSAGE_TYPES } from '../../src/types/MessageTypes';
+import type { MessageMetadata } from '../../src/types/MessageTypes';
+import type { ResolvedConfig } from '../../src/types/ConfigTypes';
+import { createMockLogger, createMockWindow } from '../utils/mock-factory';
+
+describe('ConnectionManager', () => {
+    let registry: MessageRegistry;
+    let targets: TargetManager;
+    let emitter: EventEmitter;
+    let rejectPendingForTarget: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        const logger = createMockLogger();
+        registry = new MessageRegistry(logger as any);
+        targets = new TargetManager(logger as any);
+        emitter = new EventEmitter();
+        rejectPendingForTarget = vi.fn();
+
+        new ConnectionManager({
+            config: { instanceId: 'local-instance' } as ResolvedConfig,
+            logger: logger as any,
+            emitter,
+            registry,
+            targets,
+            getHeartbeatManager: () => null,
+            onIncomingMessage: () => {},
+            sendSystemMessage: () => Promise.resolve(undefined),
+            rejectPendingForTarget,
+        });
+    });
+
+    describe('disconnect notification handling', () => {
+        function connectTarget(id: string): void {
+            targets.register(createMockWindow(id) as unknown as Window, {
+                id,
+                origin: `https://${id}.example.com`,
+            });
+            targets.markConnected(id);
+        }
+
+        function sendDisconnectFrom(senderTargetId: string): void {
+            const handlers = registry.getHandlers(SYSTEM_MESSAGE_TYPES.DISCONNECT);
+            expect(handlers).toHaveLength(1);
+
+            const metadata: MessageMetadata = {
+                messageId: 'msg-1',
+                senderId: senderTargetId,
+                origin: `https://${senderTargetId}.example.com`,
+                timestamp: Date.now(),
+                expectsResponse: true,
+            };
+
+            void handlers[0]!(
+                {
+                    senderId: 'remote-instance',
+                    reason: 'manual_disconnect',
+                    timestamp: Date.now(),
+                },
+                () => {},
+                metadata
+            );
+        }
+
+        it('should disconnect the target that sent the notification', () => {
+            connectTarget('peer-a');
+
+            sendDisconnectFrom('peer-a');
+
+            expect(targets.has('peer-a')).toBe(false);
+            expect(rejectPendingForTarget).toHaveBeenCalledWith('peer-a', 'Target disconnected');
+        });
+
+        it('should not disconnect unrelated targets when one peer disconnects', () => {
+            connectTarget('peer-a');
+            connectTarget('peer-b');
+
+            sendDisconnectFrom('peer-b');
+
+            expect(targets.has('peer-b')).toBe(false);
+            expect(targets.has('peer-a')).toBe(true);
+            expect(targets.get('peer-a')?.connected).toBe(true);
+            expect(rejectPendingForTarget).not.toHaveBeenCalledWith('peer-a', expect.anything());
+        });
+
+        it('should emit disconnected event for the sender only', () => {
+            connectTarget('peer-a');
+            connectTarget('peer-b');
+
+            const disconnectedIds: string[] = [];
+            emitter.on(SYSTEM_EVENTS.DISCONNECTED, (data: { targetId: string }) => {
+                disconnectedIds.push(data.targetId);
+            });
+
+            sendDisconnectFrom('peer-a');
+
+            expect(disconnectedIds).toEqual(['peer-a']);
+        });
+
+        it('should ignore notifications from unknown targets', () => {
+            connectTarget('peer-a');
+
+            sendDisconnectFrom('unknown-peer');
+
+            expect(targets.has('peer-a')).toBe(true);
+            expect(targets.get('peer-a')?.connected).toBe(true);
+            expect(rejectPendingForTarget).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the disconnect-wrong-target bug flagged by Copilot review on #25 (merged before the fix could land there).

The disconnect system-message handler ignored which peer sent the notification and simply tore down the first connected target. With multiple connected targets, a disconnect from peer A could kill the connection to peer B. The handler now identifies the sender via message metadata (`metadata.senderId` - the local target id assigned by message routing, not the spoofable payload `senderId`) and disconnects exactly that target. Notifications from unknown targets are logged and ignored. This follows the same pattern the `HEARTBEAT_PONG` handler already uses for the same reason.

Includes a changeset (patch bump) - merging this will update the open `chore: version packages` PR (#26).

## Test plan

- [x] New `tests/unit/ConnectionManager.test.ts` covering: sender is disconnected, unrelated targets stay connected (fails against the old code), disconnected event fires for the sender only, unknown senders are ignored
- [x] typecheck, eslint, 865 unit tests, build, size, Playwright E2E - all green locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)