### PR TITLE
chore(release): sync lockfile on version and drop manual changelog section

### DIFF
--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -16,3 +16,9 @@ Bug fixes, hardening, and tooling improvements:
   the pending `connect()` instead of hanging
 - New `EventEmitter.destroy()` and `onLimitExceeded` option
 - New `GENERAL_ERRORS.UNKNOWN` error code
+- Internal refactor: `Parley` is now a facade over `ConnectionManager` and
+  `SendPipeline` (no public API change)
+- Tooling: ESLint flat config with type-checked rules, Playwright E2E suite
+  for real cross-origin communication, per-format bundle budgets via
+  size-limit, automated releases with changesets and npm provenance, and
+  CI cleanup; added `SECURITY.md` and `CODE_OF_CONDUCT.md`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
         uses: changesets/action@v1
         with:
           # Opens/updates a 'chore: version packages' PR when changesets exist;
-          # publishes to npm (with provenance) when that PR is merged
+          # publishes to npm (with provenance) when that PR is merged.
+          # version:packages also syncs package-lock.json with the new version.
+          version: npm run version:packages
           publish: npm run release
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,57 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Fixed
-
-- Heartbeat pings and async message handling no longer create unhandled promise
-  rejections (floating promises found by the new type-aware lint rules)
-- `EventEmitter` now logs errors thrown by async event handlers instead of
-  letting them surface as unhandled rejections
-- `createBatchingAdapter()` no longer leaks its flush interval: the timer starts
-  lazily on the first event and is cleared by the new `destroy()` method, which
-  also flushes any buffered events
-- Package `exports` map now points at files that actually exist: `import`
-  resolves to `./dist/index.js` (ESM) and `require` to `./dist/index.cjs`
-  (CommonJS). Previously `import` pointed at a missing `index.mjs` and `require`
-  at the ESM build
-- Disconnecting or cleaning up a channel mid-handshake now rejects the pending
-  connect() promise instead of leaving it hanging forever
-
-### Added
-
-- Optional `destroy()` method on the `AnalyticsAdapter` interface;
-  `AnalyticsManager.removeAdapter()` and `clear()` call it automatically
-- `npm run size` script with per-format bundle budgets via size-limit
-- ESLint flat config with typescript-eslint type-checked rules
-  (`no-floating-promises`, `no-misused-promises`, `require-await`), wired into
-  `npm run lint` and CI
-- Playwright E2E suite (`npm run test:e2e`) exercising real cross-origin iframe
-  and window.open communication in Chromium: handshake round-trip, handshake
-  timeout, origin rejection, reconnect, and popup-close detection
-- `HandshakeController`: explicit handshake state machine
-  (`idle | awaiting-ack | completed | timed-out | failed`) used by both
-  channels; late or duplicate handshake events are now explicit no-ops, and
-  channels expose a readonly `handshakeState` getter
-- `EventEmitter.destroy()` removes all listeners and rejects future
-  subscriptions with a warning (no-op unsubscribe) instead of silent
-  registration; new `onLimitExceeded: 'throw' | 'warn'` constructor option
-- Root `SECURITY.md` and `CODE_OF_CONDUCT.md`
-
-### Changed
-
-- CI: removed redundant workflow (wrong Node version), deduplicated coverage
-  run, bundle size now checked per format
-- Coverage thresholds in `vitest.config.ts` raised to current actuals;
-  documentation now references the enforced thresholds instead of a fixed
-  percentage claim
-
 ## [1.0.0] - 2025-12-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "docs:preview": "vitepress preview docs",
         "size": "size-limit",
         "changeset": "changeset",
+        "version:packages": "changeset version && npm install --package-lock-only",
         "release": "npm run build && changeset publish"
     },
     "publishConfig": {


### PR DESCRIPTION
## Summary

Fixes both Copilot findings on the generated version PR (#26) at the root, so they stay fixed for every future release:

- **Lockfile out of sync**: `changeset version` only bumps `package.json`; `package-lock.json` stayed at the old version, so `npm ci` on a release would rewrite it. The release workflow now runs a `version:packages` script (`changeset version && npm install --package-lock-only`) so the lockfile is bumped in the version PR itself.
- **Stale [Unreleased] changelog section**: the hand-maintained section duplicated what the changeset generates for 1.1.0, leaving released items listed as unreleased. Its package-facing extras (decomposition note, tooling summary) are folded into `.changeset/bright-foxes-dance.md` and the manual section is removed - changesets owns release entries going forward.

When this merges, the Release workflow will regenerate #26 with the synced lockfile and the complete 1.1.0 entry.

## Test plan

- [x] Local dry-run of `npm run version:packages`: `package-lock.json` bumps to 1.1.0 and CHANGELOG.md renders the full 1.1.0 entry with no duplicated section (generated output reverted before commit)
- [ ] CI
- [ ] Regenerated #26 shows the lockfile bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)